### PR TITLE
Add L2 regularization and basic dim rdxn

### DIFF
--- a/src/baseline/model.py
+++ b/src/baseline/model.py
@@ -64,7 +64,7 @@ class FCOutputModelBCE(nn.Module):
         x = F.relu(x)
         x = F.dropout(x)
         x = self.fc3(x)
-        return F.sigmoid(x)
+        return torch.sigmoid(x)
 
 
 class BasicModel(nn.Module):
@@ -339,7 +339,12 @@ class RN(BasicModel):
         third_embedding = input_feats[:, 600:900]
         post_embedding = input_feats[:, 900:]
 
-        #For now, just take the first 64
+        # Dimensionality reduction by averaging
+        first_embedding = (first_embedding[:, ::3] + first_embedding[:, 1::3] + first_embedding[:, 2::3]) / 3
+        second_embedding = (second_embedding[:, ::3] + second_embedding[:, 1::3] + second_embedding[:, 2::3]) / 3
+        third_embedding = (third_embedding[:, ::3] + third_embedding[:, 1::3] + third_embedding[:, 2::3]) / 3
+
+        # For now, just take the first 64
         first_embedding = first_embedding[:, :OBJ_LENGTH]
         second_embedding = second_embedding[:, :OBJ_LENGTH]
         third_embedding = third_embedding[:, :OBJ_LENGTH]

--- a/src/baseline/model.py
+++ b/src/baseline/model.py
@@ -198,7 +198,7 @@ class RN(BasicModel):
         # self.coord_tensor.data.copy_(torch.from_numpy(np_coord_tensor))
 
 
-        self.optimizer = optim.Adam(self.parameters(), lr=args.lr)
+        self.optimizer = optim.Adam(self.parameters(), lr=args.lr, weight_decay=1e-5)
 
     def forward(self, input_feats, args):
         first_embedding, second_embedding, third_embedding, post_embedding = self.extract_embeddings(

--- a/src/baseline/relational.py
+++ b/src/baseline/relational.py
@@ -239,7 +239,7 @@ def main():
     """Prepare the Relational Network"""
 
     # Toggle for debugging
-    args.BCE = True
+    # args.BCE = True
 
     args.cuda = not args.no_cuda and torch.cuda.is_available()
     cuda = args.cuda


### PR DESCRIPTION
### L2 Regularization
```Python
self.optimizer = optim.Adam(self.parameters(), lr=args.lr, weight_decay=1e-5)
```
### Dimensionality Reduction
* average the values of every three features (300 -> 100)
* still take top 64
### Best AUC Score
> Test set on epoch 50: Conflict Accuracy: 49%
AUC Score: 0.7433
Training complete!

**Using**
* weight_decay=1e-5
* BCE
I'm surprised how quickly it runs on my machine (no cuda cores)

### Comments
* Low conflict score worries me. We are literally as bad as guessing even with regularization
* Maybe using all the data will fix this? I can only hope
* I think BCE should do better than NLL but they don't seem to be too different in terms of score/performance